### PR TITLE
fix: restore tar fallback when makepkg is not available

### DIFF
--- a/Alien/Package/Tgz.pm
+++ b/Alien/Package/Tgz.pm
@@ -489,7 +489,10 @@ sub build {
 		$Alien::Package::verbose=$v;
 	}
 	else {
-		die "Sorry, I cannot generate the .tgz file because /sbin/makepkg is not present.\n"
+		# Fallback to plain tar when makepkg is not available
+		# Use same method as makepkg: strip ./ prefix via sed to match Slackware format
+		$this->do("cd ".$this->unpacked_tree."; find ./ | LC_COLLATE=C sort | sed '2,\$s,^\\./,,' | tar --no-recursion -T - -czf ../$tgz")
+			or die "Package build failed";
 	}
 	return $tgz;
 }


### PR DESCRIPTION
Commit 32f04ae removed the tar fallback in Tgz::build(), requiring /sbin/makepkg (Slackware-specific) for --to-tgz conversion. This broke alien on all non-Slackware systems.

Restore the fallback using the same method as the original makepkg script.

Fixes: https://github.com/Project-OSS-Revival/alien/issues/4